### PR TITLE
Allow plugin to use custom AWS Profile

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ class ServerlessSyncS3Buckets {
     getCredentials() {
       let credentials = null;
       if (this.serverless.service.provider.profile) {
-        credentials = new s3.AWS.SharedIniFileCredentials({
+        credentials = new AWS.SharedIniFileCredentials({
           profile: this.serverless.service.provider.profile
         });
       }

--- a/index.js
+++ b/index.js
@@ -225,12 +225,25 @@ class ServerlessSyncS3Buckets {
         this.cli.consoleLog(`${cliPrefix}${chalk.yellow(message)}`);
     }
 
+    // helper method to check if a credentials profile is specified in serverless.yml and, if so, use it.
+    getCredentials() {
+      let credentials = null;
+      if (this.serverless.service.provider.profile) {
+        credentials = new s3.AWS.SharedIniFileCredentials({
+          profile: this.serverless.service.provider.profile
+        });
+      }
+
+      return credentials;
+    }
+    
     // Generates the S3 client for the current region
     client() {
         const provider = this.serverless.getProvider('aws');
         return s3.createClient({
             s3Client: new AWS.S3({
                 region: provider.getRegion(),
+                credentials: this.getCredentials()
             })
         });
     }


### PR DESCRIPTION
This adds a helper method to check if a profile is specified in serverless.yml, and if so, return a credentials object so the custom profile can be used. Otherwise, it returns null which falls back to the default. Should address issue #2. Not fully tested.